### PR TITLE
Adds Process timeout command line options

### DIFF
--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -25,7 +25,36 @@ public:
                                        const char * environment,
                                        bool shareHandles = false );
     [[nodiscard]] bool          IsRunning() const;
-    int32_t                     WaitForExit();
+
+    enum ExitReason : uint8_t
+    {
+        PROCESS_EXIT_UNDEFINED        = 0, // Special status indicating exit reason is not defined yet
+        PROCESS_EXIT_NORMAL           = 1, // Process has exited normally
+        PROCESS_EXIT_ABORTED          = 2, // Process was aborted
+        PROCESS_EXIT_TIMEOUT          = 3, // Process timed out (overall timeout)
+        PROCESS_EXIT_TIMEOUT_INACTIVE = 4  // Process timed out (from inactivity)
+    };
+
+    static const char* ExitReasonToString( uint8_t exitReason )
+    {
+        switch ( exitReason )
+        {
+        case PROCESS_EXIT_UNDEFINED:
+            return "Undefined";
+        case PROCESS_EXIT_NORMAL:
+            return "Normal";
+        case PROCESS_EXIT_ABORTED:
+            return "Aborted";
+        case PROCESS_EXIT_TIMEOUT:
+            return "Process Timeout";
+        case PROCESS_EXIT_TIMEOUT_INACTIVE:
+            return "Process Timeout Inactive";
+        default:
+            return "Unknown";
+        }
+    }
+
+    ExitReason                  WaitForExit(int32_t & exitCodeOut);
     void                        Detach();
     void                        KillProcessTree();
 
@@ -33,13 +62,14 @@ public:
     // NOTE: Owner must free the returned memory!
     bool                        ReadAllData( AString & memOut,
                                              AString & errOut,
-                                             uint32_t timeOutMS = 0 );
+                                             uint32_t timeOutMS = 0,
+                                             uint32_t outputInactivityTimeoutMs = 0 );
 
     #if defined( __WINDOWS__ )
         // Prevent handles being redirected
         void                    DisableHandleRedirection() { m_RedirectHandles = false; }
     #endif
-    [[nodiscard]] bool          HasAborted() const { return m_HasAborted; }
+    [[nodiscard]] bool          HasAborted() const { return m_ExitReason == PROCESS_EXIT_ABORTED; }
     [[nodiscard]] static uint32_t   GetCurrentId();
 
 private:
@@ -86,7 +116,7 @@ private:
         int m_StdOutRead;
         int m_StdErrRead;
     #endif
-    bool m_HasAborted;
+    ExitReason m_ExitReason;
     const volatile bool * m_MainAbortFlag; // This member is set when we must cancel processes asap when the main process dies.
     const volatile bool * m_AbortFlag;
 };

--- a/Code/Tools/FBuild/FBuild/Main.cpp
+++ b/Code/Tools/FBuild/FBuild/Main.cpp
@@ -283,16 +283,22 @@ int WrapperMainProcess( const AString & args, const FBuildOptions & options, Sys
 
     // the intermediate process will exit immediately after launching the final
     // process
-    const int32_t result = p.WaitForExit();
-    if ( result == FBUILD_FAILED_TO_SPAWN_WRAPPER_FINAL )
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit( exitCode );
+    ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
+
+    // Avoid warning in release code, but keep the ASSERT
+    (void)(exitReason);
+
+    if ( exitCode == FBUILD_FAILED_TO_SPAWN_WRAPPER_FINAL )
     {
         OUTPUT( "FBuild: Error: Intermediate process failed to spawn the final process.\n" );
-        return result;
+        return exitCode;
     }
-    else if ( result != FBUILD_OK )
+    else if ( exitCode != FBUILD_OK )
     {
-        OUTPUT( "FBuild: Error: Intermediate process failed (%i).\n", result );
-        return result;
+        OUTPUT( "FBuild: Error: Intermediate process failed (%i).\n", exitCode );
+        return exitCode;
     }
 
     // wait for final process to signal as started
@@ -344,9 +350,16 @@ int32_t WrapperModeForWSL( const FBuildOptions & options )
         return FBUILD_FAILED_TO_WSL_WRAPPER;
     }
 
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit(exitCode);
+    ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
+
+    // Avoid warning in release code, but keep the ASSERT
+    (void)(exitReason);
+
     // Return the result from the WSL process, which will itself forward the
     // result of the target process
-    return p.WaitForExit();
+    return exitCode;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -351,6 +351,36 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
                 m_NoUnity = true;
                 continue;
             }
+            else if ( thisArg == "-processtimeout" )
+            {
+                const int processTimeoutIndex = ( i + 1 );
+                uint32_t processTimeoutSecs;
+                if ( ( processTimeoutIndex >= argc ) ||
+                     ( AString::ScanS( argv[processTimeoutIndex], "%u", &processTimeoutSecs ) != 1 ) )
+                {
+                    OUTPUT( "FBuild: Error: Missing or bad <timeout (secs)> for '-processtimeout' argument\n" );
+                    OUTPUT( "Try \"%s -help\"\n", programName.Get() );
+                    return OPTIONS_ERROR;
+                }
+                m_ProcessTimeoutSecs = processTimeoutSecs;
+                i++; // skip extra arg we've consumed
+                continue;
+            }
+            else if ( thisArg == "-processoutputtimeout" )
+            {
+                const int processOutputTimeoutIndex = ( i + 1 );
+                uint32_t processOutputTimeoutSecs;
+                if ( ( processOutputTimeoutIndex >= argc ) ||
+                     ( AString::ScanS( argv[processOutputTimeoutIndex], "%u", &processOutputTimeoutSecs ) != 1 ) )
+                {
+                    OUTPUT( "FBuild: Error: Missing or bad <timeout (secs)> for '-processoutputtimeout' argument\n" );
+                    OUTPUT( "Try \"%s -help\"\n", programName.Get() );
+                    return OPTIONS_ERROR;
+                }
+                m_ProcessOutputTimeoutSecs = processOutputTimeoutSecs;
+                i++; // skip extra arg we've consumed
+                continue;
+            }
             else if ( thisArg == "-profile" )
             {
                 m_Profile = true;
@@ -671,6 +701,13 @@ void FBuildOptions::DisplayHelp( const AString & programName ) const
             " -nosummaryonerror Hide the summary if the build fails. Implies -summary.\n"
             " -profile          Output an fbuild_profiling.json describing the build.\n"
             " -progress         Show build progress bar even if stdout is redirected.\n"
+            " -processoutputtimeout <timeout (secs)>\n"
+            "                   Specify a timeout for output inactivity for spawned build\n"
+            "                   processes (in seconds) (process times out after <timeout> seconds\n"
+            "                   if no output is read on stdout or stderr) (default: 0, no timeout)\n"
+            " -processtimeout <timeout (secs)>\n"
+            "                   Specify an overall timeout for any spawned build processes\n"
+            "                   processes (in seconds) (default: 0, no timeout)\n"
             " -quiet            Don't show build output.\n"
             " -report[=json|html]\n"
             "                   Ouput report at build end. (Increases build time)\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -61,6 +61,8 @@ public:
     bool        m_GenerateDotGraphFull              = false;
     bool        m_GenerateCompilationDatabase       = false;
     bool        m_NoUnity                           = false;
+    uint32_t    m_ProcessTimeoutSecs                = 0; // Default to no timeout
+    uint32_t    m_ProcessOutputTimeoutSecs          = 0; // Default to no timeout
 
     // Cache
     bool        m_UseCacheRead                      = false;

--- a/Code/Tools/FBuild/FBuildCore/FLog.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FLog.cpp
@@ -27,9 +27,8 @@
     // TODO:LINUX TODO:MAC Clean up this _itoa_s mess
     void _itoa_s( int value, char * buffer, int bufferSize, int base )
     {
-        (void)bufferSize;
         ASSERT( base == 10 ); (void)base;
-        sprintf( buffer, "%i", value );
+        snprintf( buffer, bufferSize, "%i", value);
     }
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/CSNode.cpp
@@ -202,16 +202,18 @@ CSNode::~CSNode() = default;
     // capture all of the stdout and stderr
     AString memOut;
     AString memErr;
-    p.ReadAllData( memOut, memErr );
+    p.ReadAllData( memOut, memErr, FBuild::Get().GetOptions().m_ProcessTimeoutSecs * 1000, FBuild::Get().GetOptions().m_ProcessOutputTimeoutSecs * 1000 );
 
     // Get result
-    const int result = p.WaitForExit();
-    if ( p.HasAborted() )
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit(exitCode);
+
+    if ( exitReason == Process::PROCESS_EXIT_ABORTED )
     {
         return NODE_RESULT_FAILED;
     }
 
-    const bool ok = ( result == 0 );
+    const bool ok = exitReason == Process::PROCESS_EXIT_NORMAL && ( exitCode == 0 );
 
     // Show output if desired
     const bool showOutput = ( ok == false ) ||
@@ -224,7 +226,17 @@ CSNode::~CSNode() = default;
 
     if ( !ok )
     {
-        FLOG_ERROR( "Failed to build Object. Error: %s Target: '%s'", ERROR_STR( result ), GetName().Get() );
+        AStackString<32> errorStr;
+        if (exitReason == Process::PROCESS_EXIT_NORMAL)
+        {
+            errorStr = ERROR_STR( exitCode );
+        }
+        else
+        {
+            errorStr = Process::ExitReasonToString( exitReason );
+        }
+
+        FLOG_ERROR( "Failed to build Object. Error: %s Target: '%s'", errorStr.Get(), GetName().Get() );
         return NODE_RESULT_FAILED;
     }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -259,19 +259,20 @@ private:
                             const char * workingDir = nullptr );
 
         // determine overall result
-        inline int                      GetResult() const { return m_Result; }
+        inline int                      GetExitCode() const { return m_ExitCode; }
+        inline uint8_t                  GetExitReason() const { return m_ExitReason; }
 
         // access output/error
         inline const AString &          GetOut() const { return m_Out; }
         inline const AString &          GetErr() const { return m_Err; }
-        inline bool                     HasAborted() const { return m_Process.HasAborted(); }
 
     private:
         bool            m_HandleOutput;
         Process         m_Process;
         AString         m_Out;
         AString         m_Err;
-        int             m_Result;
+        int             m_ExitCode;
+        uint8_t         m_ExitReason;
     };
 
     // Exposed Properties

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
@@ -198,29 +198,44 @@ const char * TestNode::GetEnvironmentString() const
     // capture all of the stdout and stderr
     AString memOut;
     AString memErr;
-    const bool timedOut = !p.ReadAllData( memOut, memErr, m_TestTimeOut * 1000 );
+
+    // Use whichever value is higher, this specific test's .TestTimeOut parameter, or the command line option for
+    // process timeout.
+    uint32_t overallTimeout = Math::Max( m_TestTimeOut, FBuild::Get().GetOptions().m_ProcessTimeoutSecs );
+    p.ReadAllData( memOut, memErr, overallTimeout * 1000, FBuild::Get().GetOptions().m_ProcessOutputTimeoutSecs * 1000 );
 
     // Get result
-    const int result = p.WaitForExit();
-    if ( p.HasAborted() )
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit(exitCode);
+    if ( exitReason == Process::PROCESS_EXIT_ABORTED )
     {
         return NODE_RESULT_FAILED;
     }
 
-    if ( ( timedOut == true ) || ( result != 0 ) || ( m_TestAlwaysShowOutput == true ) )
+    const bool showOutput = m_TestAlwaysShowOutput || ( exitReason != Process::PROCESS_EXIT_NORMAL ) || ( exitCode != 0 );
+    if ( showOutput )
     {
         // something went wrong, print details
         Node::DumpOutput( job, memOut );
         Node::DumpOutput( job, memErr );
     }
 
-    if ( timedOut == true )
+    if ( exitReason == Process::PROCESS_EXIT_TIMEOUT )
     {
-        FLOG_ERROR( "Test timed out after %u s (%s)", m_TestTimeOut, m_TestExecutable.Get() );
+        FLOG_ERROR( "Test timed out after %u s (%s)", overallTimeout, m_TestExecutable.Get() );
     }
-    else if ( result != 0 )
+    else if ( ( exitReason != Process::PROCESS_EXIT_NORMAL ) || ( exitCode != 0 ) )
     {
-        FLOG_ERROR( "Test failed. Error: %s Target: '%s'", ERROR_STR( result ), GetName().Get() );
+        AStackString<32> errorStr;
+        if ( exitReason == Process::PROCESS_EXIT_NORMAL )
+        {
+            errorStr = ERROR_STR( exitCode );
+        }
+        else
+        {
+            errorStr = Process::ExitReasonToString( exitReason );
+        }
+        FLOG_ERROR( "Test failed. Error: %s Target: '%s'", errorStr.Get(), GetName().Get() );
     }
 
     // write the test output (saved for pass or fail)
@@ -239,7 +254,7 @@ const char * TestNode::GetEnvironmentString() const
     fs.Close();
 
     // did the test fail?
-    if ( ( timedOut == true ) || ( result != 0 ) )
+    if ( ( exitReason != Process::PROCESS_EXIT_NORMAL ) || ( exitCode != 0 ) )
     {
         return NODE_RESULT_FAILED;
     }

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCLR.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCLR.cpp
@@ -229,7 +229,10 @@ void TestCLR::TestCLRToCPPBridge() const
 
         Process p;
         p.Spawn( "../tmp/Test/CLR/Bridge/Bridge.exe", nullptr, nullptr, nullptr );
-        int ret = p.WaitForExit();
+
+        int ret = 0;
+        const uint8_t exitReason = p.WaitForExit(ret);
+        TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expected exit reason
         TEST_ASSERT( ret == 15613223 ); // verify expected ret code
     #endif
 }

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestDLL.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestDLL.cpp
@@ -313,7 +313,9 @@ void TestDLL::TestValidExeWithDLL() const
 
     Process p;
     TEST_ASSERT( p.Spawn( exe.Get(), nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
     TEST_ASSERT( ret == 99 );
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
@@ -71,7 +71,9 @@ void TestExe::CheckValidExe() const
 {
     Process p;
     TEST_ASSERT( p.Spawn( "../tmp/Test/Exe/exe.exe", nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expect exit reason
     TEST_ASSERT( ret == 99 ); // verify expected ret code
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestResources.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestResources.cpp
@@ -54,7 +54,9 @@ void TestResources::BuildResource() const
     // spawn exe which does a runtime check that the resource is availble
     Process p;
     TEST_ASSERT( p.Spawn( "../tmp/Test/Resources/exe.exe", nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expected exit reason
     TEST_ASSERT( ret == 1 ); // verify expected ret code
 
     // Check stats


### PR DESCRIPTION
# Description:

One of the biggest build faults that we are facing in our fastbuild based build system are seemingly inexplicable build hangs. Around 10% of our builds currently will sit and spin forever until we terminate fastbuild externally. It's also difficult to track down because we lose any of the stdout / stderr of the child process that is hanging in the event of a forcible external kill.

This change is mainly an effort for us to get more diagnostic information around:
1. What processes are failing
2. What their current state is (output from the process)
3. Minimize the impact of actually stuck processes, by terminating early and us using external retrying logic to complete the builds.

* Adds the command line flag for `-processtimeout <timeout (secs)` flag, which sets an overall timeout on all processes invoked by Fastbuild nodes. This can behave like the upper bounds for a reasonable job.

* Adds the concept and command line flag for Process Inactivity Timeout. Process Inactivity is determined by the last time any output was read on the process's stdout or stderr. This allows us to terminate processes that are no longer outputting any details, which could indicate it is hung / stuck (using output as a heuristic for activity).

Controllable via the `-processoutputtimeout <timeout (secs)>` command line flag.

* Test Node objects can define a `TestTimeOut`, and the node will choose the highest of the two values, process timeout from CLI or the value specified in the fastbuild script.
# Checklist:

The pull request:
- [ ] **Is created against the Dev branch**
- [ ] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [ ] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style**
- [ ] **Includes documentation**
