### PR TITLE
Adds Process timeout command line options

### DIFF
--- a/Code/Core/Process/Process.cpp
+++ b/Code/Core/Process/Process.cpp
@@ -51,6 +51,7 @@ Process::Process( const volatile bool * mainAbortFlag,
     , m_ChildPID( -1 )
     , m_HasAlreadyWaitTerminated( false )
 #endif
+    , m_ExitReason( PROCESS_EXIT_UNDEFINED )
     , m_MainAbortFlag( mainAbortFlag )
     , m_AbortFlag( abortFlag )
 {
@@ -65,7 +66,8 @@ Process::~Process()
 {
     if ( m_Started )
     {
-        WaitForExit();
+        int32_t exitCode = 0;
+        WaitForExit(exitCode);
     }
 }
 
@@ -464,16 +466,21 @@ bool Process::IsRunning() const
 
 // WaitForExit
 //------------------------------------------------------------------------------
-int32_t Process::WaitForExit()
+Process::ExitReason Process::WaitForExit(int32_t & exitCodeOut)
 {
     ASSERT( m_Started );
     m_Started = false;
 
-    #if defined( __WINDOWS__ )
+    if ( m_ExitReason == PROCESS_EXIT_TIMEOUT ||
+         m_ExitReason == PROCESS_EXIT_TIMEOUT_INACTIVE )
+    {
+        return m_ExitReason;
+    }
 
+    #if defined( __WINDOWS__ )
         DWORD exitCode = 0;
 
-        if ( HasAborted() == false )
+        if ( m_ExitReason != PROCESS_EXIT_ABORTED )
         {
             // Don't wait if using jobs and the process has been aborted.
             // It will be killed along with the fbuild process if the TerminateProcess has failed for any reason and
@@ -494,7 +501,8 @@ int32_t Process::WaitForExit()
         VERIFY( ::CloseHandle( GetProcessInfo().hProcess ) );
         VERIFY( ::CloseHandle( GetProcessInfo().hThread ) );
 
-        return (int32_t)exitCode;
+        exitCodeOut = (int32_t)exitCode;
+        m_ExitReason = PROCESS_EXIT_NORMAL;
     #elif defined( __LINUX__ ) || defined( __APPLE__ )
         VERIFY( close( m_StdOutRead ) == 0 );
         VERIFY( close( m_StdErrRead ) == 0 );
@@ -532,11 +540,13 @@ int32_t Process::WaitForExit()
                 break;
             }
         }
-
-        return m_ReturnStatus;
+        exitCodeOut = m_ReturnStatus;
+        m_ExitReason = PROCESS_EXIT_NORMAL;
     #else
         #error Unknown platform
     #endif
+
+    return m_ExitReason;
 }
 
 // Detach
@@ -566,9 +576,11 @@ void Process::Detach()
 //------------------------------------------------------------------------------
 bool Process::ReadAllData( AString & outMem,
                            AString & errMem,
-                           uint32_t timeOutMS )
+                           uint32_t timeOutMS,
+                           uint32_t outputInactivityTimeoutMs )
 {
     const Timer t;
+    Timer outputActivityTimer;
 
     #if defined( __LINUX__ )
         // Start with a short sleep interval to allow rapid termination of
@@ -585,6 +597,7 @@ bool Process::ReadAllData( AString & outMem,
         {
             PROFILE_SECTION( "Abort" );
             KillProcessTree();
+            m_ExitReason = PROCESS_EXIT_ABORTED;
             break;
         }
 
@@ -596,6 +609,7 @@ bool Process::ReadAllData( AString & outMem,
         // did we get some data?
         if ( ( prevOutSize != outMem.GetLength() ) || ( prevErrSize != errMem.GetLength() ) )
         {
+            outputActivityTimer.Start();
             #if defined( __LINUX__ )
                 // Reset sleep interval
                 sleepIntervalMS = 1;
@@ -614,7 +628,16 @@ bool Process::ReadAllData( AString & outMem,
                     if ( ( timeOutMS > 0 ) && ( t.GetElapsedMS() >= (float)timeOutMS ) )
                     {
                         Terminate();
+                        m_ExitReason = PROCESS_EXIT_TIMEOUT;
                         return false; // Timed out
+                    }
+
+                    if ( ( outputInactivityTimeoutMs > 0 ) &&
+                         ( outputActivityTimer.GetElapsedMS() >= (float)outputInactivityTimeoutMs) )
+                    {
+                        Terminate();
+                        m_ExitReason = PROCESS_EXIT_TIMEOUT_INACTIVE;
+                        return false;
                     }
 
                     continue; // still running - try to read
@@ -632,7 +655,16 @@ bool Process::ReadAllData( AString & outMem,
                 if ( ( timeOutMS > 0 ) && ( t.GetElapsedMS() >= static_cast<float>( timeOutMS ) ) )
                 {
                     Terminate();
+                    m_ExitReason = PROCESS_EXIT_TIMEOUT;
                     return false; // Timed out
+                }
+
+                if ( ( outputInactivityTimeoutMs > 0 ) &&
+                     ( outputActivityTimer.GetElapsedMS() >= (float)outputInactivityTimeoutMs) )
+                {
+                    Terminate();
+                    m_ExitReason = PROCESS_EXIT_TIMEOUT_INACTIVE;
+                    return false;
                 }
 
                 // no data available, but process is still going, so wait

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -25,7 +25,36 @@ public:
                                        const char * environment,
                                        bool shareHandles = false );
     [[nodiscard]] bool          IsRunning() const;
-    int32_t                     WaitForExit();
+
+    enum ExitReason : uint8_t
+    {
+        PROCESS_EXIT_UNDEFINED        = 0, // Special status indicating exit reason is not defined yet
+        PROCESS_EXIT_NORMAL           = 1, // Process has exited normally
+        PROCESS_EXIT_ABORTED          = 2, // Process was aborted
+        PROCESS_EXIT_TIMEOUT          = 3, // Process timed out (overall timeout)
+        PROCESS_EXIT_TIMEOUT_INACTIVE = 4  // Process timed out (from inactivity)
+    };
+
+    static const char* ExitReasonToString( uint8_t exitReason )
+    {
+        switch ( exitReason )
+        {
+        case PROCESS_EXIT_UNDEFINED:
+            return "Undefined";
+        case PROCESS_EXIT_NORMAL:
+            return "Normal";
+        case PROCESS_EXIT_ABORTED:
+            return "Aborted";
+        case PROCESS_EXIT_TIMEOUT:
+            return "Process Timeout";
+        case PROCESS_EXIT_TIMEOUT_INACTIVE:
+            return "Process Timeout Inactive";
+        default:
+            return "Unknown";
+        }
+    }
+
+    ExitReason                  WaitForExit(int32_t & exitCodeOut);
     void                        Detach();
     void                        KillProcessTree();
 
@@ -33,13 +62,14 @@ public:
     // NOTE: Owner must free the returned memory!
     bool                        ReadAllData( AString & memOut,
                                              AString & errOut,
-                                             uint32_t timeOutMS = 0 );
+                                             uint32_t timeOutMS = 0,
+                                             uint32_t outputInactivityTimeoutMs = 0 );
 
     #if defined( __WINDOWS__ )
         // Prevent handles being redirected
         void                    DisableHandleRedirection() { m_RedirectHandles = false; }
     #endif
-    [[nodiscard]] bool          HasAborted() const;
+    [[nodiscard]] bool          HasAborted() const { return m_ExitReason == PROCESS_EXIT_ABORTED; }
     [[nodiscard]] static uint32_t   GetCurrentId();
 
 private:
@@ -86,6 +116,7 @@ private:
         int m_StdOutRead;
         int m_StdErrRead;
     #endif
+    ExitReason m_ExitReason;
     const volatile bool * m_MainAbortFlag; // This member is set when we must cancel processes asap when the main process dies.
     const volatile bool * m_AbortFlag;
 };

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -69,7 +69,6 @@ public:
         // Prevent handles being redirected
         void                    DisableHandleRedirection() { m_RedirectHandles = false; }
     #endif
-    [[nodiscard]] bool          HasAborted() const { return m_ExitReason == PROCESS_EXIT_ABORTED; }
     [[nodiscard]] static uint32_t   GetCurrentId();
 
 private:

--- a/Code/Core/Process/Process.h
+++ b/Code/Core/Process/Process.h
@@ -69,6 +69,7 @@ public:
         // Prevent handles being redirected
         void                    DisableHandleRedirection() { m_RedirectHandles = false; }
     #endif
+    [[nodiscard]] bool          HasAborted() const;
     [[nodiscard]] static uint32_t   GetCurrentId();
 
 private:

--- a/Code/Tools/FBuild/FBuild/Main.cpp
+++ b/Code/Tools/FBuild/FBuild/Main.cpp
@@ -283,16 +283,22 @@ int WrapperMainProcess( const AString & args, const FBuildOptions & options, Sys
 
     // the intermediate process will exit immediately after launching the final
     // process
-    const int32_t result = p.WaitForExit();
-    if ( result == FBUILD_FAILED_TO_SPAWN_WRAPPER_FINAL )
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit( exitCode );
+    ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
+
+    // Avoid warning in release code, but keep the ASSERT
+    (void)(exitReason);
+
+    if ( exitCode == FBUILD_FAILED_TO_SPAWN_WRAPPER_FINAL )
     {
         OUTPUT( "FBuild: Error: Intermediate process failed to spawn the final process.\n" );
-        return result;
+        return exitCode;
     }
-    else if ( result != FBUILD_OK )
+    else if ( exitCode != FBUILD_OK )
     {
-        OUTPUT( "FBuild: Error: Intermediate process failed (%i).\n", result );
-        return result;
+        OUTPUT( "FBuild: Error: Intermediate process failed (%i).\n", exitCode );
+        return exitCode;
     }
 
     // wait for final process to signal as started
@@ -344,9 +350,16 @@ int32_t WrapperModeForWSL( const FBuildOptions & options )
         return FBUILD_FAILED_TO_WSL_WRAPPER;
     }
 
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit(exitCode);
+    ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
+
+    // Avoid warning in release code, but keep the ASSERT
+    (void)(exitReason);
+
     // Return the result from the WSL process, which will itself forward the
     // result of the target process
-    return p.WaitForExit();
+    return exitCode;
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.cpp
@@ -351,6 +351,36 @@ FBuildOptions::OptionsResult FBuildOptions::ProcessCommandLine( int argc, char *
                 m_NoUnity = true;
                 continue;
             }
+            else if ( thisArg == "-processtimeout" )
+            {
+                const int processTimeoutIndex = ( i + 1 );
+                uint32_t processTimeoutSecs;
+                if ( ( processTimeoutIndex >= argc ) ||
+                     ( AString::ScanS( argv[processTimeoutIndex], "%u", &processTimeoutSecs ) != 1 ) )
+                {
+                    OUTPUT( "FBuild: Error: Missing or bad <timeout (secs)> for '-processtimeout' argument\n" );
+                    OUTPUT( "Try \"%s -help\"\n", programName.Get() );
+                    return OPTIONS_ERROR;
+                }
+                m_ProcessTimeoutSecs = processTimeoutSecs;
+                i++; // skip extra arg we've consumed
+                continue;
+            }
+            else if ( thisArg == "-processoutputtimeout" )
+            {
+                const int processOutputTimeoutIndex = ( i + 1 );
+                uint32_t processOutputTimeoutSecs;
+                if ( ( processOutputTimeoutIndex >= argc ) ||
+                     ( AString::ScanS( argv[processOutputTimeoutIndex], "%u", &processOutputTimeoutSecs ) != 1 ) )
+                {
+                    OUTPUT( "FBuild: Error: Missing or bad <timeout (secs)> for '-processoutputtimeout' argument\n" );
+                    OUTPUT( "Try \"%s -help\"\n", programName.Get() );
+                    return OPTIONS_ERROR;
+                }
+                m_ProcessOutputTimeoutSecs = processOutputTimeoutSecs;
+                i++; // skip extra arg we've consumed
+                continue;
+            }
             else if ( thisArg == "-profile" )
             {
                 m_Profile = true;
@@ -671,6 +701,13 @@ void FBuildOptions::DisplayHelp( const AString & programName ) const
             " -nosummaryonerror Hide the summary if the build fails. Implies -summary.\n"
             " -profile          Output an fbuild_profiling.json describing the build.\n"
             " -progress         Show build progress bar even if stdout is redirected.\n"
+            " -processoutputtimeout <timeout (secs)>\n"
+            "                   Specify a timeout for output inactivity for spawned build\n"
+            "                   processes (in seconds) (process times out after <timeout> seconds\n"
+            "                   if no output is read on stdout or stderr) (default: 0, no timeout)\n"
+            " -processtimeout <timeout (secs)>\n"
+            "                   Specify an overall timeout for any spawned build processes\n"
+            "                   processes (in seconds) (default: 0, no timeout)\n"
             " -quiet            Don't show build output.\n"
             " -report[=json|html]\n"
             "                   Ouput report at build end. (Increases build time)\n"

--- a/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
+++ b/Code/Tools/FBuild/FBuildCore/FBuildOptions.h
@@ -61,6 +61,8 @@ public:
     bool        m_GenerateDotGraphFull              = false;
     bool        m_GenerateCompilationDatabase       = false;
     bool        m_NoUnity                           = false;
+    uint32_t    m_ProcessTimeoutSecs                = 0; // Default to no timeout
+    uint32_t    m_ProcessOutputTimeoutSecs          = 0; // Default to no timeout
 
     // Cache
     bool        m_UseCacheRead                      = false;

--- a/Code/Tools/FBuild/FBuildCore/FLog.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FLog.cpp
@@ -27,8 +27,9 @@
     // TODO:LINUX TODO:MAC Clean up this _itoa_s mess
     void _itoa_s( int value, char * buffer, int bufferSize, int base )
     {
+        (void)bufferSize;
         ASSERT( base == 10 ); (void)base;
-        snprintf( buffer, bufferSize, "%i", value);
+        sprintf( buffer, "%i", value );
     }
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/FLog.cpp
+++ b/Code/Tools/FBuild/FBuildCore/FLog.cpp
@@ -27,9 +27,8 @@
     // TODO:LINUX TODO:MAC Clean up this _itoa_s mess
     void _itoa_s( int value, char * buffer, int bufferSize, int base )
     {
-        (void)bufferSize;
         ASSERT( base == 10 ); (void)base;
-        sprintf( buffer, "%i", value );
+        snprintf( buffer, bufferSize, "%i", value);
     }
 #endif
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ExecNode.cpp
@@ -209,15 +209,17 @@ ExecNode::~ExecNode()
     // capture all of the stdout and stderr
     AString memOut;
     AString memErr;
-    p.ReadAllData( memOut, memErr );
+    p.ReadAllData( memOut, memErr, FBuild::Get().GetOptions().m_ProcessTimeoutSecs * 1000, FBuild::Get().GetOptions().m_ProcessOutputTimeoutSecs * 1000 );
 
     // Get result
-    const int result = p.WaitForExit();
-    if ( p.HasAborted() )
+    int32_t exitCode = 0;
+    const uint8_t exitReason = p.WaitForExit( exitCode );
+
+    if ( exitReason == Process::PROCESS_EXIT_ABORTED )
     {
         return NODE_RESULT_FAILED;
     }
-    const bool buildFailed = ( result != m_ExecReturnCode );
+    const bool buildFailed = (exitReason != Process::PROCESS_EXIT_NORMAL) || ( exitCode != m_ExecReturnCode );
 
     // Print output if appropriate
     if ( buildFailed ||
@@ -231,7 +233,16 @@ ExecNode::~ExecNode()
     // did the executable fail?
     if ( buildFailed )
     {
-        FLOG_ERROR( "Execution failed. Error: %s Target: '%s'", ERROR_STR( result ), GetName().Get() );
+        AStackString<32> errorStr;
+        if ( exitReason == Process::PROCESS_EXIT_NORMAL )
+        {
+            errorStr = ERROR_STR( exitCode );
+        }
+        else
+        {
+            errorStr = Process::ExitReasonToString( exitReason );
+        }
+        FLOG_ERROR( "Execution failed. Error: %s Target: '%s'", errorStr.Get(), GetName().Get() );
         return NODE_RESULT_FAILED;
     }
 

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -358,7 +358,7 @@ ObjectNode::~ObjectNode()
     // Handle MSCL warnings if not already a failure
     // If "warnings as errors" is enabled (/WX) we don't need to check
     // (since compilation will fail anyway, and the output will be shown)
-    if ( ( ch.GetResult() == 0 ) && !m_CompilerFlags.IsWarningsAsErrorsMSVC() )
+    if ( ( ( ch.GetExitReason() == Process::PROCESS_EXIT_NORMAL ) && ( ch.GetExitCode() == 0 ) ) && !m_CompilerFlags.IsWarningsAsErrorsMSVC() )
     {
         if ( IsClangCl() )
         {
@@ -1870,7 +1870,8 @@ bool ObjectNode::BuildPreprocessedOutput( const Args & fullArgs, Job * job, bool
         // stderr, and we don't want to see that unless there is a problem)
         // NOTE: Output is omitted in case the compiler has been aborted because we don't care about the errors
         // caused by the manual process abortion (process killed)
-        if ( ( ch.GetResult() != 0 ) && !ch.HasAborted() )
+        if ( ( ch.GetExitReason() != Process::PROCESS_EXIT_ABORTED ) && 
+             ( ch.GetExitReason() != Process::PROCESS_EXIT_NORMAL || ch.GetExitCode() != 0 ) )
         {
             // Use the error text, but if it's empty, use the output
             if ( ch.GetErr().IsEmpty() == false )
@@ -2187,7 +2188,7 @@ bool ObjectNode::BuildFinalOutput( Job * job, const Args & fullArgs ) const
     if ( !ch.SpawnCompiler( job, GetName(), GetCompiler(), compiler, fullArgs, workingDir.IsEmpty() ? nullptr : workingDir.Get() ) )
     {
         // did spawn fail, or did we spawn and fail to compile?
-        if ( ch.GetResult() != 0 )
+        if ( ( ch.GetExitReason() != Process::PROCESS_EXIT_NORMAL ) || ( ch.GetExitCode() != 0 ) )
         {
             // failed to compile
 
@@ -2206,7 +2207,7 @@ bool ObjectNode::BuildFinalOutput( Job * job, const Args & fullArgs ) const
     else
     {
         // Handle warnings for compilation that passed
-        if ( ch.GetResult() == 0 )
+        if ( ch.GetExitReason() == Process::PROCESS_EXIT_NORMAL && ch.GetExitCode() == 0 )
         {
             if ( IsMSVC() )
             {
@@ -2236,7 +2237,7 @@ bool ObjectNode::BuildFinalOutput( Job * job, const Args & fullArgs ) const
         // output file to disk. In that case, we write the static analysis
         // results as the output. This avoids a "file missing despite success"
         // error
-        if ( ch.GetResult() == 0 )
+        if ( ch.GetExitReason() == Process::PROCESS_EXIT_NORMAL && ch.GetExitCode() == 0 )
         {
             if ( IsClang() || IsClangCl() )
             {
@@ -2261,7 +2262,8 @@ bool ObjectNode::BuildFinalOutput( Job * job, const Args & fullArgs ) const
 ObjectNode::CompileHelper::CompileHelper( bool handleOutput, const volatile bool * abortPointer )
     : m_HandleOutput( handleOutput )
     , m_Process( FBuild::GetAbortBuildPointer(), abortPointer )
-    , m_Result( 0 )
+    , m_ExitCode( 0 )
+    , m_ExitReason( Process::PROCESS_EXIT_UNDEFINED )
 {
 }
 
@@ -2305,17 +2307,17 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
     }
 
     // capture all of the stdout and stderr
-    m_Process.ReadAllData( m_Out, m_Err );
+    m_Process.ReadAllData( m_Out, m_Err, FBuild::Get().GetOptions().m_ProcessTimeoutSecs * 1000, FBuild::Get().GetOptions().m_ProcessOutputTimeoutSecs * 1000 );
 
     // Get result
-    m_Result = m_Process.WaitForExit();
-    if ( m_Process.HasAborted() )
+    m_ExitReason = m_Process.WaitForExit(m_ExitCode);
+    if ( m_ExitReason == Process::PROCESS_EXIT_ABORTED )
     {
         return false;
     }
 
     // Handle special types of failures
-    HandleSystemFailures( job, m_Result, m_Out, m_Err );
+    HandleSystemFailures( job, m_ExitCode, m_Out, m_Err );
 
     #if defined( ENABLE_FAKE_SYSTEM_FAILURE )
         // Fake system failure for tests
@@ -2328,8 +2330,9 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
             }
 
             // Add fake failure
-            ASSERT( m_Result == 0 ); // Should not have real failures if we're faking them
-            m_Result = 1;
+            ASSERT( m_ExitCode == 0 ); // Should not have real failures if we're faking them
+            m_ExitReason = Process::PROCESS_EXIT_NORMAL;
+            m_ExitCode = 1;
             job->Error( "Injecting system failure (sFakeSystemFailure)\n" );
             job->OnSystemError();
 
@@ -2365,15 +2368,30 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
     }
 
     // failed?
-    if ( m_Result != 0 )
+    const bool buildFailed = ( m_ExitReason != Process::PROCESS_EXIT_NORMAL ) || ( m_ExitReason != 0 );
+    if ( buildFailed )
     {
+        const bool showOutput = m_HandleOutput ||
+            ( m_ExitReason == Process::PROCESS_EXIT_TIMEOUT ) ||
+            ( m_ExitReason == Process::PROCESS_EXIT_TIMEOUT_INACTIVE);
+
         // output 'stdout' which may contain errors for some compilers
-        if ( m_HandleOutput )
+        if ( showOutput )
         {
             DumpOutput( job, name, m_Out );
         }
 
-        job->Error( "Failed to build Object. Error: %s Target: '%s'\n", ERROR_STR( m_Result ), name.Get() );
+        AStackString<32> errorStr;
+        if ( m_ExitReason == Process::PROCESS_EXIT_NORMAL )
+        {
+            errorStr = ERROR_STR( m_ExitCode );
+        }
+        else
+        {
+            errorStr = Process::ExitReasonToString( m_ExitReason );
+        }
+
+        job->Error( "Failed to build Object. Error: %s Target: '%s'\n", errorStr.Get(), name.Get() );
 
         return false;
     }

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.cpp
@@ -2368,7 +2368,7 @@ bool ObjectNode::CompileHelper::SpawnCompiler( Job * job,
     }
 
     // failed?
-    const bool buildFailed = ( m_ExitReason != Process::PROCESS_EXIT_NORMAL ) || ( m_ExitReason != 0 );
+    const bool buildFailed = ( m_ExitReason == Process::PROCESS_EXIT_NORMAL && m_ExitReason != 0 ) || ( m_ExitReason != Process::PROCESS_EXIT_NORMAL );
     if ( buildFailed )
     {
         const bool showOutput = m_HandleOutput ||

--- a/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
+++ b/Code/Tools/FBuild/FBuildCore/Graph/ObjectNode.h
@@ -259,19 +259,20 @@ private:
                             const char * workingDir = nullptr );
 
         // determine overall result
-        inline int                      GetResult() const { return m_Result; }
+        inline int                      GetExitCode() const { return m_ExitCode; }
+        inline uint8_t                  GetExitReason() const { return m_ExitReason; }
 
         // access output/error
         inline const AString &          GetOut() const { return m_Out; }
         inline const AString &          GetErr() const { return m_Err; }
-        inline bool                     HasAborted() const { return m_Process.HasAborted(); }
 
     private:
         bool            m_HandleOutput;
         Process         m_Process;
         AString         m_Out;
         AString         m_Err;
-        int             m_Result;
+        int             m_ExitCode;
+        uint8_t         m_ExitReason;
     };
 
     // Exposed Properties

--- a/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
+++ b/Code/Tools/FBuild/FBuildCore/Graph/TestNode.cpp
@@ -202,7 +202,7 @@ const char * TestNode::GetEnvironmentString() const
 
     // Use whichever value is higher, this specific test's .TestTimeOut parameter, or the command line option for
     // process timeout.
-    uint32_t overallTimeout = Math::Max( m_TestTimeOut, FBuild::Get().GetOptions().m_ProcessTimeoutSecs );
+    const uint32_t overallTimeout = Math::Max( m_TestTimeOut, FBuild::Get().GetOptions().m_ProcessTimeoutSecs );
     p.ReadAllData( memOut, memErr, overallTimeout * 1000, FBuild::Get().GetOptions().m_ProcessOutputTimeoutSecs * 1000 );
 
     // Get result

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestCLR.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestCLR.cpp
@@ -229,7 +229,10 @@ void TestCLR::TestCLRToCPPBridge() const
 
         Process p;
         p.Spawn( "../tmp/Test/CLR/Bridge/Bridge.exe", nullptr, nullptr, nullptr );
-        int ret = p.WaitForExit();
+
+        int ret = 0;
+        const uint8_t exitReason = p.WaitForExit(ret);
+        TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expected exit reason
         TEST_ASSERT( ret == 15613223 ); // verify expected ret code
     #endif
 }

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestDLL.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestDLL.cpp
@@ -313,7 +313,9 @@ void TestDLL::TestValidExeWithDLL() const
 
     Process p;
     TEST_ASSERT( p.Spawn( exe.Get(), nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL );
     TEST_ASSERT( ret == 99 );
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestExe.cpp
@@ -71,7 +71,9 @@ void TestExe::CheckValidExe() const
 {
     Process p;
     TEST_ASSERT( p.Spawn( "../tmp/Test/Exe/exe.exe", nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expect exit reason
     TEST_ASSERT( ret == 99 ); // verify expected ret code
 }
 

--- a/Code/Tools/FBuild/FBuildTest/Tests/TestResources.cpp
+++ b/Code/Tools/FBuild/FBuildTest/Tests/TestResources.cpp
@@ -54,7 +54,9 @@ void TestResources::BuildResource() const
     // spawn exe which does a runtime check that the resource is availble
     Process p;
     TEST_ASSERT( p.Spawn( "../tmp/Test/Resources/exe.exe", nullptr, nullptr, nullptr ) );
-    const int ret = p.WaitForExit();
+    int ret = 0;
+    const uint8_t exitReason = p.WaitForExit(ret);
+    TEST_ASSERT( exitReason == Process::PROCESS_EXIT_NORMAL ); // verify expected exit reason
     TEST_ASSERT( ret == 1 ); // verify expected ret code
 
     // Check stats


### PR DESCRIPTION
# Description:

One of the biggest build faults that we are facing in our fastbuild based build system are seemingly inexplicable build hangs. Around 10% of our builds currently will sit and spin forever until we terminate fastbuild externally. It's also difficult to track down because we lose any of the stdout / stderr of the child process that is hanging in the event of a forcible external kill.

This change is mainly an effort for us to get more diagnostic information around:
1. What processes are failing
2. What their current state is (output from the process)
3. Minimize the impact of actually stuck processes, by terminating early and us using external retrying logic to complete the builds.

* Adds the command line flag for `-processtimeout <timeout (secs)>` flag, which sets an overall timeout on all processes invoked by Fastbuild nodes. This can behave like the upper bounds for a reasonable job.

* Adds the concept and command line flag for Process Inactivity Timeout. Process Inactivity is determined by the last time any output was read on the process's stdout or stderr. This allows us to terminate processes that are no longer outputting any details, which could indicate it is hung / stuck (using output as a heuristic for activity).

Controllable via the `-processoutputtimeout <timeout (secs)>` command line flag.

* Test Node objects can define a `TestTimeOut`, and the node will choose the highest of the two values, process timeout from CLI or the value specified in the fastbuild script.
# Checklist:

The pull request:
- [x] **Is created against the Dev branch**
- [x] **Is self-contained**
- [ ] **Compiles on Windows, OSX and Linux**
- [ ] **Has accompanying tests**
- [ ] **Passes existing tests**
- [x] **Keeps Windows, OSX and Linux at parity**
- [ ] **Follows the code style** (note: Tries to at least)
- [ ] **Includes documentation**
